### PR TITLE
A couple of compile fixes:

### DIFF
--- a/tests/rules.mk
+++ b/tests/rules.mk
@@ -29,7 +29,7 @@ endif
 	@echo "Running tests:"
 	@cd tests && ./testmain $(TESTS)
 
-tests/testmain: tests/testmain.o $(patsubst %.cpp,%.o,$(wildcard tests/test[0-9][0-9][0-9].cpp)) libxplc.a libxplc-cxx.a $(LIBS)
+tests/testmain: tests/testmain.o $(patsubst %.cpp,%.o,$(wildcard tests/test[0-9][0-9][0-9].cpp)) libxplc.a libxplc-cxx.a
 
 tests/testobj.dll: tests/testobj.o libxplc-cxx.a
 

--- a/tests/vars.mk
+++ b/tests/vars.mk
@@ -19,5 +19,12 @@
 #
 # $Id: vars.mk,v 1.12 2002/11/22 23:03:37 pphaneuf Exp $
 
+
+ifneq ("$(enable_loader)", "no")
+ifneq ("$(with_dlopen)", "no")
+tests/testmain: LDLIBS+=$(with_dlopen)
+endif
+endif
+
 CLEAN+=tests/testmain tests/testobj.dll
 

--- a/xplc/moduleloader.cpp
+++ b/xplc/moduleloader.cpp
@@ -62,7 +62,7 @@ Module* Module::loadModule(const char* modulename) {
 
   switch(moduleinfo->version_major) {
 #ifdef UNSTABLE
-  case -1:
+  case (unsigned int)-1:
     /* nothing to do */
     break;
 #endif


### PR DESCRIPTION
- fix a "narrowing conversion" error that shows up in gcc 10
- fix linking against libdl when the library isn't in /lib